### PR TITLE
Upgraded hook targets to deface overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ If you'd like to run tests:
 
 
 To Do
-***
+-------
 
 * Write more/better tests
 * Finish i18n implementation 
 
 Known Issues
-***
+-------
 
 * A user created in the 'user' tab, or an already existing user with an added 'wholesaler' flag will not be able to purchase at wholesale price. They will see the retail and wholesale price, but when added to cart will purchase at retail price. Only accounts created using wholesale interface work properly.
 * Deface override for admin_tabs (Adds wholesalers tab to admin interface) isn't targeting hook correctly, and has been set to insert to bottom of the div#store-menu ul instead.

--- a/README.md
+++ b/README.md
@@ -41,10 +41,17 @@ If you'd like to run tests:
 
 
 To Do
------
+***
 
 * Write more/better tests
 * Finish i18n implementation 
+
+Known Issues
+***
+
+* A user created in the 'user' tab, or an already existing user with an added 'wholesaler' flag will not be able to purchase at wholesale price. They will see the retail and wholesale price, but when added to cart will purchase at retail price. Only accounts created using wholesale interface work properly.
+* Deface override for admin_tabs (Adds wholesalers tab to admin interface) isn't targeting hook correctly, and has been set to insert to bottom of the div#store-menu ul instead.
+
 
     
 

--- a/lib/spree_wholesale/custom_hooks.rb
+++ b/lib/spree_wholesale/custom_hooks.rb
@@ -67,7 +67,7 @@ Deface::Override.new(:virtual_path => 'admin/orders/index',
 # insert_after :admin_tabs,                 'admin/hooks/wholesale_tab'
 Deface::Override.new(:virtual_path => "layouts/admin",
 :name => "admin-wholesale-tab",
-:insert_after => "div#admin-menu",
+:insert_bottom => "div#admin-menu ul",
 :partial => "admin/hooks/wholesale_tab")
 
   end

--- a/lib/spree_wholesale/custom_hooks.rb
+++ b/lib/spree_wholesale/custom_hooks.rb
@@ -67,7 +67,7 @@ Deface::Override.new(:virtual_path => 'admin/orders/index',
 # insert_after :admin_tabs,                 'admin/hooks/wholesale_tab'
 Deface::Override.new(:virtual_path => "layouts/admin",
 :name => "admin-wholesale-tab",
-:insert_after => "[data-hook='admin_tabs']",
+:insert_after => "div#admin-menu",
 :partial => "admin/hooks/wholesale_tab")
 
   end

--- a/lib/spree_wholesale/custom_hooks.rb
+++ b/lib/spree_wholesale/custom_hooks.rb
@@ -80,7 +80,7 @@ Deface::Override.new(:virtual_path => 'admin/orders/index',
 # This override targets the list which wraps the admin_tabs hook. It's not matching for some reason in
 # spree 0.60.0 when set directly onto the admin_tabs hook, so this is the workaround.
 Deface::Override.new(:virtual_path => "layouts/admin",
-:name => "admin-wholesale-tab",
+:name => "admin-wholesale-tab-ul",
 :insert_bottom => "div#admin-menu ul",
 :partial => "admin/hooks/wholesale_tab",
 :disabled => false)

--- a/lib/spree_wholesale/custom_hooks.rb
+++ b/lib/spree_wholesale/custom_hooks.rb
@@ -8,74 +8,90 @@
 Deface::Override.new(:virtual_path => 'orders/_line_item',
 :name => 'cart_item_price',
 :replace => "[data-hook='cart_item_price'], #cart_item_price[data-hook]",
-:partial => "hooks/cart_item_price")
+:partial => "hooks/cart_item_price",
+:disabled => false)
 
 #replace :cart_item_total,                 'hooks/cart_item_total'
 Deface::Override.new(:virtual_path => 'orders/_line_item',
 :name => 'cart_item_total',
 :replace => "[data-hook='cart_item_total'], #cart_item_total[data-hook]",
-:partial => "hooks/cart_item_total")
+:partial => "hooks/cart_item_total",
+:disabled => false)
 
 #replace :admin_product_form_right,        'admin/hooks/product_form_right'
 Deface::Override.new(:virtual_path => 'admin/products/form',
 :name => 'productform_right',
 :replace => "[data-hook='admin_product_form_right'], #admin_product_form_right[data-hook]",
-:partial => "admin/hooks/product_form_right")
+:partial => "admin/hooks/product_form_right",
+:disabled => false)
 
 #insert_before :account_my_orders,         'hooks/wholesale_customer'
 Deface::Override.new(:virtual_path => 'users/show',
 :name => 'wholesale-my-orders',
 :insert_before => "[data-hook='account_my_orders'], #account_my_orders[data-hook]",
-:partial => "hooks/wholesale_customer")
+:partial => "hooks/wholesale_customer",
+:disabled => false)
 
 #insert_before :inside_cart_form,          'hooks/wholesale_customer_id'
 Deface::Override.new(:virtual_path => 'orders/edit',
 :name => 'id_inside_cartform',
 :insert_before => "[data-hook='inside_cart_form'], #inside_cart_form[data-hook]",
-:partial => "hooks/wholesale_customer_id")
+:partial => "hooks/wholesale_customer_id",
+:disabled => false)
 
 #insert_before :checkout_payment_step,     'hooks/wholesale_payment_options'
 Deface::Override.new(:virtual_path => 'checkout/payment',
 :name => 'checkout_payment_step',
 :insert_before => "[data-hook='checkout_payment_step'], #customer_payment_step[data-hook]",
-:partial => "hooks/wholesale_payment_options")
+:partial => "hooks/wholesale_payment_options",
+:disabled => false)
 
 
 #insert_after  :admin_order_show_buttons,  'hooks/wholesale_customer_id'
 Deface::Override.new(:virtual_path => 'orders/show',
 :name => 'admin-order-show-buttons',
 :insert_after => "[data-hook='admin_order_show_buttons'], #admin_order_show_buttons[data-hook]",
-:partial => "hooks/wholesale_customer_id")
+:partial => "hooks/wholesale_customer_id",
+:disabled => false)
 
 
 #insert_after :admin_orders_index_headers, 'admin/hooks/admin_orders_index_headers'
 Deface::Override.new(:virtual_path => 'admin/orders/index',
 :name => 'admin-orders-headers',
 :insert_bottom => "[data-hook='admin_orders_index_headers'], #admin_orders_index_headers[data-hook]",
-:partial => "admin/hooks/admin_orders_index_headers")
+:partial => "admin/hooks/admin_orders_index_headers",
+:disabled => false)
 
 # insert_after :admin_orders_index_rows,    'admin/hooks/admin_orders_index_rows'
 Deface::Override.new(:virtual_path => 'admin/orders/index',
 :name => 'admin-orders-rows',
 :insert_bottom => "[data-hook='admin_orders_index_rows'], #admin_orders_index_rows[data-hook]",
-:partial => "admin/hooks/admin_orders_index_rows")
+:partial => "admin/hooks/admin_orders_index_rows",
+:disabled => false)
 
 #insert_after :admin_orders_index_search,  'admin/hooks/admin_orders_index_search'
 Deface::Override.new(:virtual_path => 'admin/orders/index',
 :name => 'admin-orders-search',
 :insert_bottom => "[data-hook='admin_orders_index_search'], #admin_orders_index_search[data-hook]",
-:partial => "admin/hooks/admin_orders_index_search")
+:partial => "admin/hooks/admin_orders_index_search",
+:disabled => false)
 
 # insert_after :admin_tabs,                 'admin/hooks/wholesale_tab'
-=begin
+# This override targets the list which wraps the admin_tabs hook. It's not matching for some reason in
+# spree 0.60.0 when set directly onto the admin_tabs hook, so this is the workaround.
 Deface::Override.new(:virtual_path => "layouts/admin",
 :name => "admin-wholesale-tab",
 :insert_bottom => "div#admin-menu ul",
-:partial => "admin/hooks/wholesale_tab")
-=end
+:partial => "admin/hooks/wholesale_tab",
+:disabled => false)
 
+
+# insert_after :admin_tabs,                 'admin/hooks/wholesale_tab'
+# This is the 'proper' way of accessing the admin_tabs hook, but it doesn't work for me, hence above.
+# DISABLED
 Deface::Override.new(:virtual_path => "layouts/admin",
 :name => "admin-wholesale-tab",
 :insert_bottom => "[data-hook='admin_tabs'], #admin_tabs[data-hook]",
-:partial => "admin/hooks/wholesale_tab")
+:partial => "admin/hooks/wholesale_tab",
+:disabled => true)
 

--- a/lib/spree_wholesale/custom_hooks.rb
+++ b/lib/spree_wholesale/custom_hooks.rb
@@ -1,25 +1,74 @@
 module SpreeWholesale
   require 'deface'
   class CustomHooks < Spree::ThemeSupport::HookListener
-        
-    replace :cart_item_price,                 'hooks/cart_item_price'
-    replace :cart_item_total,                 'hooks/cart_item_total'
-    replace :admin_product_form_right,        'admin/hooks/product_form_right'
-    
-    insert_before :account_my_orders,         'hooks/wholesale_customer'
-    insert_before :inside_cart_form,          'hooks/wholesale_customer_id'
-    insert_before :checkout_payment_step,     'hooks/wholesale_payment_options'
-    insert_after  :admin_order_show_buttons,  'hooks/wholesale_customer_id'
-    
-    
-    insert_after :admin_orders_index_headers, 'admin/hooks/admin_orders_index_headers'
-    insert_after :admin_orders_index_rows,    'admin/hooks/admin_orders_index_rows'
-    insert_after :admin_orders_index_search,  'admin/hooks/admin_orders_index_search'
-    # insert_after :admin_tabs,                 'admin/hooks/wholesale_tab'
-    Deface::Override.new(:virtual_path => 'layouts/admin',
-                          :name => "admin-wholesale-tab",
-                          :insert_bottom => "[data-hook='admin_tabs']",
-                          :partial => "admin/hooks/wholesale_tab")
-    
+
+#replace :cart_item_price,                 'hooks/cart_item_price'
+Deface::Override.new(:virtual_path => 'orders/_line_item',
+                          :name => 'cart_item_price',
+                          :insert_before => "[data-hook='cart_item_price']",
+                          :partial => "hooks/cart_item_price")
+                          
+#replace :cart_item_total,                 'hooks/cart_item_total'
+Deface::Override.new(:virtual_path => 'orders/_line_item',
+                          :name => 'cart_item_total',
+                          :insert_before => "[data-hook='cart_item_total']",
+                          :partial => "hooks/cart_item_total")
+
+#replace :admin_product_form_right,        'admin/hooks/product_form_right'
+Deface::Override.new(:virtual_path => 'admin/products/form',
+                          :name => 'productform_right',
+                          :insert_before => "[data-hook='admin_product_form_right']",
+                          :partial => "admin/hooks/product_form_right")
+
+#insert_before :account_my_orders,         'hooks/wholesale_customer'
+Deface::Override.new(:virtual_path => 'users/show',
+                          :name => 'wholesale-my-orders',
+                          :insert_before => "[data-hook='account_my_orders']",
+                          :partial => "hooks/wholesale_customer")
+
+#insert_before :inside_cart_form,          'hooks/wholesale_customer_id'
+Deface::Override.new(:virtual_path => 'orders/edit',
+                          :name => 'id_inside_cartform',
+                          :insert_before => "[data-hook='inside_cart_form']",
+                          :partial => "hooks/wholesale_customer_id")
+                          
+#insert_before :checkout_payment_step,     'hooks/wholesale_payment_options'    
+Deface::Override.new(:virtual_path => 'checkout/payment',
+                          :name => 'checkout_payment_step',
+                          :insert_before => "[data-hook='checkout_payment_step']",
+                          :partial => "hooks/wholesale_payment_options")
+
+
+#insert_after  :admin_order_show_buttons,  'hooks/wholesale_customer_id'
+    Deface::Override.new(:virtual_path => 'orders/show',
+                          :name => 'admin-order-show-buttons',
+                          :insert_bottom => "[data-hook='admin_order_show_buttons']",
+                          :partial => "hooks/wholesale_customer_id")
+
+
+#insert_after :admin_orders_index_headers, 'admin/hooks/admin_orders_index_headers'
+Deface::Override.new(:virtual_path => 'admin/orders/index',
+:name => 'admin-orders-headers',
+:insert_bottom => "[data-hook='admin_orders_index_headers']",
+:partial => "admin/hooks/admin_orders_index_headers")
+
+# insert_after :admin_orders_index_rows,    'admin/hooks/admin_orders_index_rows'
+Deface::Override.new(:virtual_path => 'admin/orders/index',
+:name => 'admin-orders-rows',
+:insert_bottom => "[data-hook='admin_orders_index_rows']",
+:partial => "admin/hooks/admin_orders_index_rows")
+
+#insert_after :admin_orders_index_search,  'admin/hooks/admin_orders_index_search'
+Deface::Override.new(:virtual_path => 'admin/orders/index',
+:name => 'admin-orders-search',
+:insert_bottom => "[data-hook='admin_orders_index_search']",
+:partial => "admin/hooks/admin_orders_index_search")
+
+# insert_after :admin_tabs,                 'admin/hooks/wholesale_tab'
+Deface::Override.new(:virtual_path => 'layouts/admin',
+:name => "admin-wholesale-tab",
+:insert_bottom => "[data-hook='admin_tabs']",
+:partial => "admin/hooks/wholesale_tab")
+
   end
 end

--- a/lib/spree_wholesale/custom_hooks.rb
+++ b/lib/spree_wholesale/custom_hooks.rb
@@ -5,19 +5,19 @@ module SpreeWholesale
 #replace :cart_item_price,                 'hooks/cart_item_price'
 Deface::Override.new(:virtual_path => 'orders/_line_item',
                           :name => 'cart_item_price',
-                          :insert_before => "[data-hook='cart_item_price']",
+                          :replace => "[data-hook='cart_item_price']",
                           :partial => "hooks/cart_item_price")
                           
 #replace :cart_item_total,                 'hooks/cart_item_total'
 Deface::Override.new(:virtual_path => 'orders/_line_item',
                           :name => 'cart_item_total',
-                          :insert_before => "[data-hook='cart_item_total']",
+                          :replace => "[data-hook='cart_item_total']",
                           :partial => "hooks/cart_item_total")
 
 #replace :admin_product_form_right,        'admin/hooks/product_form_right'
 Deface::Override.new(:virtual_path => 'admin/products/form',
                           :name => 'productform_right',
-                          :insert_before => "[data-hook='admin_product_form_right']",
+                          :replace => "[data-hook='admin_product_form_right']",
                           :partial => "admin/hooks/product_form_right")
 
 #insert_before :account_my_orders,         'hooks/wholesale_customer'

--- a/lib/spree_wholesale/custom_hooks.rb
+++ b/lib/spree_wholesale/custom_hooks.rb
@@ -1,74 +1,81 @@
-module SpreeWholesale
-  require 'deface'
-  class CustomHooks < Spree::ThemeSupport::HookListener
+  require 'deface'  
+  
+  #Hooks have been replaced by Deface overrides
+  #Check out https://github.com/railsdog/deface for a quick overview of how it works and how to use it.
+  #
 
 #replace :cart_item_price,                 'hooks/cart_item_price'
 Deface::Override.new(:virtual_path => 'orders/_line_item',
-                          :name => 'cart_item_price',
-                          :replace => "[data-hook='cart_item_price']",
-                          :partial => "hooks/cart_item_price")
-                          
+:name => 'cart_item_price',
+:replace => "[data-hook='cart_item_price'], #cart_item_price[data-hook]",
+:partial => "hooks/cart_item_price")
+
 #replace :cart_item_total,                 'hooks/cart_item_total'
 Deface::Override.new(:virtual_path => 'orders/_line_item',
-                          :name => 'cart_item_total',
-                          :replace => "[data-hook='cart_item_total']",
-                          :partial => "hooks/cart_item_total")
+:name => 'cart_item_total',
+:replace => "[data-hook='cart_item_total'], #cart_item_total[data-hook]",
+:partial => "hooks/cart_item_total")
 
 #replace :admin_product_form_right,        'admin/hooks/product_form_right'
 Deface::Override.new(:virtual_path => 'admin/products/form',
-                          :name => 'productform_right',
-                          :replace => "[data-hook='admin_product_form_right']",
-                          :partial => "admin/hooks/product_form_right")
+:name => 'productform_right',
+:replace => "[data-hook='admin_product_form_right'], #admin_product_form_right[data-hook]",
+:partial => "admin/hooks/product_form_right")
 
 #insert_before :account_my_orders,         'hooks/wholesale_customer'
 Deface::Override.new(:virtual_path => 'users/show',
-                          :name => 'wholesale-my-orders',
-                          :insert_before => "[data-hook='account_my_orders']",
-                          :partial => "hooks/wholesale_customer")
+:name => 'wholesale-my-orders',
+:insert_before => "[data-hook='account_my_orders'], #account_my_orders[data-hook]",
+:partial => "hooks/wholesale_customer")
 
 #insert_before :inside_cart_form,          'hooks/wholesale_customer_id'
 Deface::Override.new(:virtual_path => 'orders/edit',
-                          :name => 'id_inside_cartform',
-                          :insert_before => "[data-hook='inside_cart_form']",
-                          :partial => "hooks/wholesale_customer_id")
-                          
-#insert_before :checkout_payment_step,     'hooks/wholesale_payment_options'    
+:name => 'id_inside_cartform',
+:insert_before => "[data-hook='inside_cart_form'], #inside_cart_form[data-hook]",
+:partial => "hooks/wholesale_customer_id")
+
+#insert_before :checkout_payment_step,     'hooks/wholesale_payment_options'
 Deface::Override.new(:virtual_path => 'checkout/payment',
-                          :name => 'checkout_payment_step',
-                          :insert_before => "[data-hook='checkout_payment_step']",
-                          :partial => "hooks/wholesale_payment_options")
+:name => 'checkout_payment_step',
+:insert_before => "[data-hook='checkout_payment_step'], #customer_payment_step[data-hook]",
+:partial => "hooks/wholesale_payment_options")
 
 
 #insert_after  :admin_order_show_buttons,  'hooks/wholesale_customer_id'
-    Deface::Override.new(:virtual_path => 'orders/show',
-                          :name => 'admin-order-show-buttons',
-                          :insert_after => "[data-hook='admin_order_show_buttons']",
-                          :partial => "hooks/wholesale_customer_id")
+Deface::Override.new(:virtual_path => 'orders/show',
+:name => 'admin-order-show-buttons',
+:insert_after => "[data-hook='admin_order_show_buttons'], #admin_order_show_buttons[data-hook]",
+:partial => "hooks/wholesale_customer_id")
 
 
 #insert_after :admin_orders_index_headers, 'admin/hooks/admin_orders_index_headers'
 Deface::Override.new(:virtual_path => 'admin/orders/index',
 :name => 'admin-orders-headers',
-:insert_bottom => "[data-hook='admin_orders_index_headers']",
+:insert_bottom => "[data-hook='admin_orders_index_headers'], #admin_orders_index_headers[data-hook]",
 :partial => "admin/hooks/admin_orders_index_headers")
 
 # insert_after :admin_orders_index_rows,    'admin/hooks/admin_orders_index_rows'
 Deface::Override.new(:virtual_path => 'admin/orders/index',
 :name => 'admin-orders-rows',
-:insert_bottom => "[data-hook='admin_orders_index_rows']",
+:insert_bottom => "[data-hook='admin_orders_index_rows'], #admin_orders_index_rows[data-hook]",
 :partial => "admin/hooks/admin_orders_index_rows")
 
 #insert_after :admin_orders_index_search,  'admin/hooks/admin_orders_index_search'
 Deface::Override.new(:virtual_path => 'admin/orders/index',
 :name => 'admin-orders-search',
-:insert_bottom => "[data-hook='admin_orders_index_search']",
+:insert_bottom => "[data-hook='admin_orders_index_search'], #admin_orders_index_search[data-hook]",
 :partial => "admin/hooks/admin_orders_index_search")
 
 # insert_after :admin_tabs,                 'admin/hooks/wholesale_tab'
+=begin
 Deface::Override.new(:virtual_path => "layouts/admin",
 :name => "admin-wholesale-tab",
 :insert_bottom => "div#admin-menu ul",
 :partial => "admin/hooks/wholesale_tab")
+=end
 
-  end
-end
+Deface::Override.new(:virtual_path => "layouts/admin",
+:name => "admin-wholesale-tab",
+:insert_bottom => "[data-hook='admin_tabs'], #admin_tabs[data-hook]",
+:partial => "admin/hooks/wholesale_tab")
+

--- a/lib/spree_wholesale/custom_hooks.rb
+++ b/lib/spree_wholesale/custom_hooks.rb
@@ -65,9 +65,9 @@ Deface::Override.new(:virtual_path => 'admin/orders/index',
 :partial => "admin/hooks/admin_orders_index_search")
 
 # insert_after :admin_tabs,                 'admin/hooks/wholesale_tab'
-Deface::Override.new(:virtual_path => 'layouts/admin',
+Deface::Override.new(:virtual_path => "layouts/admin",
 :name => "admin-wholesale-tab",
-:insert_bottom => "[data-hook='admin_tabs']",
+:insert_after => "[data-hook='admin_tabs']",
 :partial => "admin/hooks/wholesale_tab")
 
   end

--- a/lib/spree_wholesale/custom_hooks.rb
+++ b/lib/spree_wholesale/custom_hooks.rb
@@ -42,7 +42,7 @@ Deface::Override.new(:virtual_path => 'checkout/payment',
 #insert_after  :admin_order_show_buttons,  'hooks/wholesale_customer_id'
     Deface::Override.new(:virtual_path => 'orders/show',
                           :name => 'admin-order-show-buttons',
-                          :insert_bottom => "[data-hook='admin_order_show_buttons']",
+                          :insert_after => "[data-hook='admin_order_show_buttons']",
                           :partial => "hooks/wholesale_customer_id")
 
 

--- a/lib/spree_wholesale/custom_hooks.rb
+++ b/lib/spree_wholesale/custom_hooks.rb
@@ -1,4 +1,5 @@
 module SpreeWholesale
+  require 'deface'
   class CustomHooks < Spree::ThemeSupport::HookListener
         
     replace :cart_item_price,                 'hooks/cart_item_price'
@@ -14,7 +15,11 @@ module SpreeWholesale
     insert_after :admin_orders_index_headers, 'admin/hooks/admin_orders_index_headers'
     insert_after :admin_orders_index_rows,    'admin/hooks/admin_orders_index_rows'
     insert_after :admin_orders_index_search,  'admin/hooks/admin_orders_index_search'
-    insert_after :admin_tabs,                 'admin/hooks/wholesale_tab'
+    # insert_after :admin_tabs,                 'admin/hooks/wholesale_tab'
+    Deface::Override.new(:virtual_path => 'layouts/admin',
+                          :name => "admin-wholesale-tab",
+                          :insert_bottom => "[data-hook='admin_tabs']",
+                          :partial => "admin/hooks/wholesale_tab")
     
   end
 end

--- a/lib/spree_wholesale/version.rb
+++ b/lib/spree_wholesale/version.rb
@@ -1,3 +1,3 @@
 module SpreeWholesale
-  VERSION = "0.59.0.3"
+  VERSION = "0.59.0.4"
 end

--- a/lib/spree_wholesale/version.rb
+++ b/lib/spree_wholesale/version.rb
@@ -1,3 +1,3 @@
 module SpreeWholesale
-  VERSION = "0.59.0.2"
+  VERSION = "0.59.0.3"
 end

--- a/lib/spree_wholesale/version.rb
+++ b/lib/spree_wholesale/version.rb
@@ -1,3 +1,3 @@
 module SpreeWholesale
-  VERSION = "0.59.0.5"
+  VERSION = "0.59.0.6"
 end

--- a/lib/spree_wholesale/version.rb
+++ b/lib/spree_wholesale/version.rb
@@ -1,3 +1,3 @@
 module SpreeWholesale
-  VERSION = "0.59.0.0"
+  VERSION = "0.59.0.2"
 end

--- a/lib/spree_wholesale/version.rb
+++ b/lib/spree_wholesale/version.rb
@@ -1,3 +1,3 @@
 module SpreeWholesale
-  VERSION = "0.59.0.4"
+  VERSION = "0.59.0.5"
 end

--- a/spree_wholesale.gemspec
+++ b/spree_wholesale.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   
   s.add_dependency('spree_core', '>= 0.60.0')
   s.add_dependency('spree_auth', '>= 0.60.0')
+  s.add_dependency('deface')
   
   s.add_development_dependency('spree_sample',       '>= 0.60.0')
   s.add_development_dependency('shoulda',            '>= 2.11.3')


### PR DESCRIPTION
Hi. The hooks weren't working perfectly for me in edge spree and rails, so I decided to move them over to deface overrides. Most still target hooks, except for the admin menu tab which was giving trouble. (It's targeted on the div#store-menu ul instead.

Spent some time trying to make sure everything is still in place, and it looks good to me.

Thanks,

Sanarothe
