### PR TITLE
Got an exception in admin/orders in spree from git, this is a quick fix.

### DIFF
--- a/app/controllers/admin/wholesalers_controller.rb
+++ b/app/controllers/admin/wholesalers_controller.rb
@@ -37,7 +37,8 @@ class Admin::WholesalersController < Admin::ResourceController
       params[:search] ||= {}
       params[:search][:meta_sort] ||= "company.asc"
       @search = Wholesaler.search(params[:search])
-      @collection = @search.paginate(:per_page => Spree::Config[:admin_products_per_page], :page => params[:page])
+      # Rails 3.1.0 uses kaminari for pagination. https://github.com/amatsuda/kaminari
+      @collection = @search.page(params[:page]).per(Spree::Config[:admin_products_per_page])
     end
  
 end

--- a/app/views/admin/wholesalers/index.html.erb
+++ b/app/views/admin/wholesalers/index.html.erb
@@ -49,8 +49,7 @@
   </tbody>
 </table>
 
-<%= will_paginate(:previous_label => "&#171; #{t('previous')}", :next_label => "#{t('next')} &#187;") %>
-
+<%= paginate @wholesalers %>
 
 
 <% content_for :sidebar do %>

--- a/lib/spree_wholesale/custom_hooks.rb
+++ b/lib/spree_wholesale/custom_hooks.rb
@@ -1,8 +1,8 @@
-  require 'deface'  
+require 'deface'  
   
-  #Hooks have been replaced by Deface overrides
-  #Check out https://github.com/railsdog/deface for a quick overview of how it works and how to use it.
-  #
+#Hooks have been replaced by Deface overrides
+#Check out https://github.com/railsdog/deface for a quick overview of how it works and how to use it.
+#
 
 #replace :cart_item_price,                 'hooks/cart_item_price'
 Deface::Override.new(:virtual_path => 'orders/_line_item',
@@ -70,11 +70,19 @@ Deface::Override.new(:virtual_path => 'admin/orders/index',
 :disabled => false)
 
 #insert_after :admin_orders_index_search,  'admin/hooks/admin_orders_index_search'
+# Fix for edge Spree.
 Deface::Override.new(:virtual_path => 'admin/orders/index',
-:name => 'admin-orders-search',
-:insert_bottom => "[data-hook='admin_orders_index_search'], #admin_orders_index_search[data-hook]",
-:partial => "admin/hooks/admin_orders_index_search",
-:disabled => false)
+  :name => 'admin-orders-search-compat',
+#  :insert_bottom => "[data-hook='admin_orders_index_search'], #admin_orders_index_search[data-hook]",
+  :insert_bottom => "#admin_orders_index_search[data-hook]",
+  :partial => "admin/hooks/admin_orders_index_search",
+  :disabled => false)
+  
+Deface::Override.new(:virtual_path => 'admin/orders/index',
+  :name => 'admin-orders-search',
+  :insert_before => "[data-hook='admin_orders_index_search_buttons']",
+  :partial => "admin/hooks/admin_orders_index_search",
+  :disabled => false)
 
 # insert_after :admin_tabs,                 'admin/hooks/wholesale_tab'
 # This override targets the list which wraps the admin_tabs hook. It's not matching for some reason in


### PR DESCRIPTION
Fix custom hooks: order search form had a field appended outside the <form> tag, throwing an exception.

Changed the hook to insert before the search button; kept the old override intact (just renamed it). Not tested with older Spree versions!

Works with Spree edge as of Aug 02 2011.
