### PR TITLE
Refactoring checkout_controller_decorator

### DIFF
--- a/app/controllers/checkout_controller_decorator.rb
+++ b/app/controllers/checkout_controller_decorator.rb
@@ -1,7 +1,6 @@
 CheckoutController.instance_eval do 
-  
   before_filter :get_addresses
-  
+  before_filter :remove_payments_attributes
 end
 
 CheckoutController.class_eval do 
@@ -11,40 +10,11 @@ CheckoutController.class_eval do
     @order.bill_address = current_user.wholesaler.bill_address
     @order.ship_address = current_user.wholesaler.ship_address
   end
-  
-  
-  
-  # Updates the order and advances to the next state (when possible.)
-  def update
-    if @order.is_wholesale? && @order.state == "payment" && @order.wholesaler.terms != "Credit Card" && params[:order_pay_at] == "later"
-      @order.next
-      return redirect_to(checkout_state_path(@order.state))
-    end
-    
-    if @order.update_attributes(object_params)
 
-      fire_event('spree.checkout.update')
-      if @order.respond_to?(:coupon_code) && @order.coupon_code.present?
-        fire_event('spree.checkout.coupon_code_added', :coupon_code => @order.coupon_code)
-      end
-
-      if @order.next
-        state_callback(:after)
-      else
-        flash[:error] = I18n.t(:payment_processing_failed)
-        respond_with(@order, :location => checkout_state_path(@order.state))
-        return
-      end
-
-      if @order.state == "complete" || @order.completed?
-        flash[:notice] = I18n.t(:order_processed_successfully)
-        flash[:commerce_tracking] = "nothing special"
-        respond_with(@order, :location => completion_route)
-      else
-        respond_with(@order, :location => checkout_state_path(@order.state))
-      end
-    else
-      respond_with(@order) { |format| format.html { render :edit } }
+  def remove_payments_attributes
+    if @order.is_wholesale? && @order.payment? && @order.wholesaler.terms != "Credit Card" && params[:order_pay_at] == "later"
+      params.delete :payment_source if params[:payment_source].present?
+      params[:order].delete :payments_attributes if params[:order][:payments_attributes].present?
     end
   end
 end


### PR DESCRIPTION
This simplifies the checkout_controller_decorator to use spree_core's checkout_controller#update method and doesn't circumvent the checkout process states and allows for the order to be cleanly finish/finalize.
